### PR TITLE
Fix error message print function argument type 

### DIFF
--- a/lib/NetworkTest.php
+++ b/lib/NetworkTest.php
@@ -1843,7 +1843,7 @@ class NetworkTest {
             }
             else if ((abs($s - filesize($file))/$s) > 0.1) {
               $validated['test_files_dir'] = sprintf('The test file %s in --test_files_dir %s is more than 10% different in size from expected (%d vs %d)', 
-                                                     $f, $dir, filesize($file), $s);
+                                                     $f, $dir, filesize($file), filesize($s));
               break;
             }
           }


### PR DESCRIPTION
Change from `$s` to `filesize($s)` to match `%d`, and this is what the error msg intended to print.