### PR TITLE
Error msg add var (int) cast to match %d, change size of ping.js to 6 in downlink-files.ini

### DIFF
--- a/lib/NetworkTest.php
+++ b/lib/NetworkTest.php
@@ -1843,7 +1843,7 @@ class NetworkTest {
             }
             else if ((abs($s - filesize($file))/$s) > 0.1) {
               $validated['test_files_dir'] = sprintf('The test file %s in --test_files_dir %s is more than 10% different in size from expected (%d vs %d)', 
-                                                     $f, $dir, filesize($file), $s);
+                                                     $f, $dir, filesize($file), filesize($s));
               break;
             }
           }

--- a/lib/NetworkTest.php
+++ b/lib/NetworkTest.php
@@ -1843,7 +1843,7 @@ class NetworkTest {
             }
             else if ((abs($s - filesize($file))/$s) > 0.1) {
               $validated['test_files_dir'] = sprintf('The test file %s in --test_files_dir %s is more than 10% different in size from expected (%d vs %d)', 
-                                                     $f, $dir, filesize($file), filesize($s));
+                                                     $f, $dir, filesize($file), (int)$s);
               break;
             }
           }

--- a/lib/config/downlink-files.ini
+++ b/lib/config/downlink-files.ini
@@ -1,5 +1,5 @@
 # names of downlink test files and their corresponding sizes in bytes
-ping.js=5
+ping.js=6
 test10gb.bin=10737418240
 test1gb.bin=1073741824
 test500mb.bin=524288000


### PR DESCRIPTION
Cast string value to int to match %d in sprintf function.
Size of ping.js (in web_probe folder) is 6 instead of 5.

Please ignore the first commit, it was based on wrong understanding, the second commit reversed it.