### PR TITLE
Please review changes to lib/NetworkTest.php

### DIFF
--- a/lib/NetworkTest.php
+++ b/lib/NetworkTest.php
@@ -50,7 +50,7 @@ class NetworkTest {
    * Test files to skip when validating the test_files_dir parameter if they do
    * not exist
    */
-  const TEST_FILES_DIR_SKIP_VALIDATION = 'test1gb.bin,test10gb.bin';
+  const TEST_FILES_DIR_SKIP_VALIDATION = 'test500mb.bin,test1gb.bin,test10gb.bin';
   
   /**
    * set to TRUE if abort_threshold reached
@@ -1723,7 +1723,7 @@ class NetworkTest {
         
         if ($response) {
           if (isset($response['lowest_status']) && isset($response['highest_status']) && isset($response['results']) && count($response['results'])) {
-            if ($response['lowest_status'] >= 200 && $response['highest_status'] < 300) {
+            if ($response['lowest_status'] >= 100 && $response['highest_status'] < 300) {
               print_msg(sprintf('curl request(s) for samples %d of %d completed successfully - highest response status is %d and %d results exist', $i+1, $samples, $response['highest_status'], count($response['results'])), $this->verbose, __FILE__, __LINE__);
               $speeds = array();
               $times = array();
@@ -1769,7 +1769,7 @@ class NetworkTest {
                 print_msg(sprintf('Test sample %d of %d for URL %s successful. Mean/median rate is [%s %s] Mb/s. Mean/median time is [%s %s] ms. Total rate is %s Mb/s. Total time is %s secs. Slowest thread was %s secs. Fastest thread was %s secs. %s MB transfer on %d reqs', $i+1, $samples, $url, $meanMbs, $medianMbs, $meanTime, $medianTime, round($totalMbs, 4), round($totalTime/1000, 4), round($slowestThread/1000, 4), round($fastestThread/1000, 4), $mbTransferred, $numRequests), $this->verbose, __FILE__, __LINE__);
               }
             }
-            else print_msg(sprintf('curl request(s) failed for URL %s because lowest and highest status %d/%d is not in the 2XX range', $url, $response['lowest_status'], $response['highest_status']), $this->verbose, __FILE__, __LINE__, TRUE);
+            else print_msg(sprintf('curl request(s) failed for URL %s because lowest and highest status %d/%d is not in the 1XX-2XX range', $url, $response['lowest_status'], $response['highest_status']), $this->verbose, __FILE__, __LINE__, TRUE);
           }
           else print_msg(sprintf('curl request(s) did not return highest_status or results for URL %s', $url), $this->verbose, __FILE__, __LINE__, TRUE);
         }


### PR DESCRIPTION
Hello,

I'm are working on deploying Cloudharmony network test harness to our internal test suite and encountered a couple issues.

_**Change 1**:  add 100+ http status codes to expected range_

During POST request (UPLINK), CURL sends a HTTP Expect request (100-continue) and if the server accepts it, it sends the full request payload. This means the UPLINK test code path receives 2 responses from the server. The "100" status code for Expect request and then the "200" status code for the full payload. Unfortunately the UPLINK test fails if it received any status code that is not in the 200-299 ranges.

**ERROR: curl request(s) failed for URL https://example.com/web-probe/up.html because lowest and highest status 100/200 is not in the 2XX range**

Running curl from the command line it shows the status codes returned:

> POST / HTTP/1.1
> Host: example.com
> User-Agent: curl/7.58.0
> Accept: */*
> Content-Length: 52032378
> Content-Type: application/x-www-form-urlencoded
> Expect: 100-continue
>
**< HTTP/1.1 100 Continue
< HTTP/1.1 200 OK**
< Server: nginx/1.16.1
< Date: Wed, 06 May 2020 22:57:40 GMT
< Content-Type: text/html
< Content-Length: 612
< Last-Modified: Mon, 04 May 2020 17:40:17 GMT
< Connection: keep-alive
< ETag: "5eb05381-264"
< Accept-Ranges: bytes

HTTP 100+ status codes are informational only and should not cause a test failure. If the server 
in fact rejects the payload after receiving the HTTP Expect request, it will send a HTTP status code 417and the harness will fail as expected.
https://tools.ietf.org/html/rfc7231#section-6.2.1
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect


_**Change 2**: exclude test500mb.bin from test file validation_
We use --test_files_dir to point to the location of the web-probe directory containing the test files. The following error occurs at start up of the main test script.

**ERROR: argument --test_files_dir is invalid - --test_files_dir /var/www/html/web-probe does not contain the file test500mb.bin**

test500mb.bin is not included in the web-probe repo and has to be created along with the other large files. It is not needed to run the test and should be exempt from the test file validation. 

I would greatly appreciate any help to address these issues. If the issues cannot be addressed as shown in this PR, please let me know and provide correct usage or workarounds for the issue if available.

Thank you in advance,
Akan
